### PR TITLE
Merge Request for Block Storage Size Updation

### DIFF
--- a/client/block_storage_client.go
+++ b/client/block_storage_client.go
@@ -111,6 +111,40 @@ func (c *Client) DeleteBlockStorage(blockStorageID string, project_id int, locat
 	return nil
 }
 
+func (c *Client) UpdateBlockStorageSize(item *models.BlockStorageUpgrade, blockStorageID string, project_id int, location string) (map[string]interface{}, error) {
+	buf := bytes.Buffer{}
+	err := json.NewEncoder(&buf).Encode(item)
+	if err != nil {
+		return nil, err
+	}
+	urlNode := c.Api_endpoint + "block_storage/" + blockStorageID + "/vm/upgrade/"
+	req, err := http.NewRequest("PUT", urlNode, &buf)
+	if err != nil {
+		return nil, err
+	}
+	addParamsAndHeaders(req, c.Api_key, c.Auth_token, project_id, location)
+	response, err := c.HttpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	err = CheckResponseStatus(response)
+	if err != nil {
+		return nil, err
+	}
+
+	defer response.Body.Close()
+	resBody, _ := ioutil.ReadAll(response.Body)
+	stringresponse := string(resBody)
+	resBytes := []byte(stringresponse)
+
+	var jsonRes map[string]interface{}
+	err = json.Unmarshal(resBytes, &jsonRes)
+	if err != nil {
+		return nil, err
+	}
+	return jsonRes, nil
+}
+
 func addParamsAndHeaders(req *http.Request, Api_key string, Auth_token string, project_id int, location string) *http.Request {
 	params := req.URL.Query()
 	params.Add("apikey", Api_key)

--- a/client/client.go
+++ b/client/client.go
@@ -424,6 +424,10 @@ func (c *Client) CreateVpc(location string, item *models.VpcCreate, project_id s
 	if err != nil {
 		return nil, err
 	}
+	err = CheckResponseStatus(response)
+	if err != nil {
+		return nil, err
+	}
 	defer response.Body.Close()
 	resBody, _ := ioutil.ReadAll(response.Body)
 	stringresponse := string(resBody)

--- a/e2e/blockstorage/resource_block_storage.go
+++ b/e2e/blockstorage/resource_block_storage.go
@@ -160,7 +160,7 @@ func resourceUpdateBlockStorage(ctx context.Context, d *schema.ResourceData, m i
 		prevName, currName := d.GetChange("name")
 		log.Printf("[INFO] prevName %s, currName %s", prevName.(string), currName.(string))
 		d.Set("name", prevName)
-		return diags
+		return diag.Errorf("Renaming of Block Storage is not permitted!")
 	}
 	if d.HasChange("size") {
 		if d.Get("status") == "Attached" {

--- a/models/block_storage.go
+++ b/models/block_storage.go
@@ -6,6 +6,12 @@ type BlockStorageCreate struct {
 	IOPS int     `json:"iops"`
 }
 
+type BlockStorageUpgrade struct {
+	Name  string  `json:"name"`
+	Size  float64 `json:"block_storage_size"`
+	VM_ID float64 `json:"vm_id"`
+}
+
 type BlockStorageResponse struct {
 	Code    int                    `json:"code"`
 	Data    []BlockStorage         `json:"data"`


### PR DESCRIPTION
Made changes to the size field in Block Storage. This will enable the user to upgrade the size of block storage if it is attached to a node. Currently updation of name is prevented via terraform.