### PR TITLE
location bug fix

### DIFF
--- a/client/ssh_key_client.go
+++ b/client/ssh_key_client.go
@@ -28,12 +28,12 @@ func (c *Client) AddSshKey(item models.AddSshKey, project_id string) (map[string
 
 	params.Add("apikey", c.Api_key)
 	params.Add("project_id", project_id)
-	params.Add("location", item.Location) // 
+	params.Add("location", item.Location) //
 
 	req.URL.RawQuery = params.Encode()
-// 	//  Log full URL and location
-// log.Printf("[DEBUG] Full request URL: %s", req.URL.String())
-// log.Printf("[DEBUG] Location param in AddSshKey: %s", item.Location)
+	// 	//  Log full URL and location
+	// log.Printf("[DEBUG] Full request URL: %s", req.URL.String())
+	// log.Printf("[DEBUG] Location param in AddSshKey: %s", item.Location)
 
 	req.Header.Add("Authorization", "Bearer "+c.Auth_token)
 	req.Header.Add("Content-Type", "application/json")

--- a/client/ssh_key_client.go
+++ b/client/ssh_key_client.go
@@ -190,7 +190,7 @@ func (c *Client) GetSshKeyByPk(pk string, project_id string, location string) (*
 	defer resp.Body.Close()
 
 	if resp.StatusCode == 404 {
-		return nil, nil // not found
+		return nil, fmt.Errorf("SSH key with ID %s not found", pk)
 	}
 
 	if resp.StatusCode != 200 {
@@ -214,7 +214,7 @@ func (c *Client) GetSshKeyByPk(pk string, project_id string, location string) (*
 	}
 
 	if len(data.Data) == 0 {
-		return nil, nil // Not found
+		return nil, fmt.Errorf("SSH key with ID %s not found in response", pk)
 	}
 
 	return &data.Data[0], nil

--- a/docs/resources/ssh_key.md
+++ b/docs/resources/ssh_key.md
@@ -18,6 +18,7 @@ This resource allows you to manage ssh key on your e2e clusters. When applied, a
     label = <name of ssh key : String>
     ssh_key = <your public key : String>
     project_id = <project_id:string>
+    location="Delhi"
  }
 ```
 
@@ -30,6 +31,7 @@ This resource allows you to manage ssh key on your e2e clusters. When applied, a
 - `label` (String) specify The label(name) of the ssh key
 - `ssh_key` (String) specify the ssh key.
 - `project_id` (String) specify the project id in which the reserve ip is to be created. To find the project id, please refer to our [`API Documentation`](https://docs.e2enetworks.com/api/myaccount/#/paths/pbac-projects-header/get)
+- `location` (String) specify the location of the ssh key
 
 
 ### Read-Only

--- a/e2e/ssh_key/resource_ssh_key.go
+++ b/e2e/ssh_key/resource_ssh_key.go
@@ -102,10 +102,18 @@ func resourceReadSshKey(ctx context.Context, d *schema.ResourceData, m interface
 		return diag.FromErr(err)
 	}
 	if sshKey == nil {
-		log.Printf("[WARN] SSH key with pk=%s not found", pk)
-		d.SetId("")
-		return diags
-	}
+	log.Printf("[WARN] SSH key with ID %s not found", pk)
+	d.SetId("")
+
+	diags = append(diags, diag.Diagnostic{
+		Severity: diag.Warning,
+		Summary:  "SSH key not found",
+		Detail:   "The SSH key may have been deleted manually.",
+	})
+
+	return diags
+}
+
 
 	d.Set("label", sshKey.Label)
 	d.Set("ssh_key", sshKey.Ssh_key)

--- a/models/ssh_key.go
+++ b/models/ssh_key.go
@@ -10,10 +10,11 @@ type SshKey struct {
 	Label     string `json:"label"`
 	Ssh_key   string `json:"ssh_key"`
 	Pk        int    `json:"pk"`
-	Timestamp string `json:"timestamp"`
+	Timestamp string `json:"timestamp"`  
 }
 
 type AddSshKey struct {
 	Label  string `json:"label"`
 	SshKey string `json:"ssh_key"`
+	Location string `json:"location"`
 }


### PR DESCRIPTION
Fix: SSH Key Resource –Location bug fixed

Improved the ssh_key Terraform resource to work consistently across regions and support accurate import, read, and delete operations by fixing the location bug

Key Updates:
Added location field – Users must now specify the location (e.g., Delhi, Mumbai) where the SSH key is to be created. Fixes 412 errors due to missing or invalid location

Improved Read logic – Finds the SSH key using pk, not label, for accuracy.

Fixed Delete & Exists – Both functions extract location from the resource state.
