### PR TITLE
Fix LoadBalancer location error and update LoadBalancer, VPC, and SFS docs

### DIFF
--- a/client/lb_client.go
+++ b/client/lb_client.go
@@ -121,6 +121,7 @@ func (c *Client) DeleteLoadBalancer(lbId string, location string, project_id str
 		return err
 	}
 
+	log.Printf("[INFO] CLIENT | LOAD BALANCER DELETE")
 	req, err = c.AddParamsAndHeader(req, location, project_id)
 	if err != nil {
 		return err
@@ -131,6 +132,11 @@ func (c *Client) DeleteLoadBalancer(lbId string, location string, project_id str
 		return err
 	}
 	if response.StatusCode != http.StatusOK {
+		respBody := new(bytes.Buffer)
+		_, err := respBody.ReadFrom(response.Body)
+		if err != nil {
+			return fmt.Errorf("got a non 200 status code: %v", response.StatusCode)
+		}
 		return fmt.Errorf("got a non 200 status code: %v - %s", response.StatusCode, respBody.String())
 	}
 

--- a/client/lb_client.go
+++ b/client/lb_client.go
@@ -44,6 +44,7 @@ func (c *Client) NewLoadBalancer(item *models.LoadBalancerCreate, project_id str
 	params := req.URL.Query()
 	params.Add("apikey", c.Api_key)
 	params.Add("project_id", project_id)
+	params.Add("location", item.Location)
 	req.URL.RawQuery = params.Encode()
 	req.Header.Add("Authorization", "Bearer "+c.Auth_token)
 	req.Header.Add("Content-Type", "application/json")
@@ -113,33 +114,71 @@ func (c *Client) GetLoadBalancerInfo(lbId string, location string, project_id st
 	return jsonRes, nil
 }
 
+// func (c *Client) DeleteLoadBalancer(lbId string, location string, project_id string) error {
+// 	urlLbInfo := c.Api_endpoint + "appliances/" + lbId + "/"
+// 	req, err := http.NewRequest("DELETE", urlLbInfo, nil)
+// 	if err != nil {
+// 		return err
+// 	}
+
+// 	log.Printf("[INFO] CLIENT | LOAD BALANCER DELETE")
+
+// 	req, err = c.AddParamsAndHeader(req, location, project_id)
+// 	if err != nil {
+// 		return err
+// 	}
+
+// 	response, err := c.HttpClient.Do(req)
+// 	if err != nil {
+// 		return err
+// 	}
+// 	if response.StatusCode != http.StatusOK {
+// 		respBody := new(bytes.Buffer)
+// 		_, err := respBody.ReadFrom(response.Body)
+// 		if err != nil {
+// 			return fmt.Errorf("got a non 200 status code: %v", response.StatusCode)
+// 		}
+// 		return fmt.Errorf("got a non 200 status code: %v - %s", response.StatusCode, respBody.String())
+// 	}
+
+// 	return nil
+// }
+
 func (c *Client) DeleteLoadBalancer(lbId string, location string, project_id string) error {
 	urlLbInfo := c.Api_endpoint + "appliances/" + lbId + "/"
+	log.Printf("[INFO] CLIENT | LB DELETE | Request URL: %s", urlLbInfo)
+
 	req, err := http.NewRequest("DELETE", urlLbInfo, nil)
 	if err != nil {
+		log.Printf("[ERROR] CLIENT | LB DELETE | Failed to create request: %v", err)
 		return err
 	}
-
-	log.Printf("[INFO] CLIENT | LOAD BALANCER DELETE")
 
 	req, err = c.AddParamsAndHeader(req, location, project_id)
 	if err != nil {
+		log.Printf("[ERROR] CLIENT | LB DELETE | Failed to add headers/params: %v", err)
 		return err
 	}
 
+	log.Printf("[INFO] CLIENT | LB DELETE | Sending DELETE request for LB ID: %s, Location: %s, Project: %s", lbId, location, project_id)
 	response, err := c.HttpClient.Do(req)
 	if err != nil {
+		log.Printf("[ERROR] CLIENT | LB DELETE | Request failed: %v", err)
 		return err
 	}
+	defer response.Body.Close()
+
+	respBody := new(bytes.Buffer)
+	_, _ = respBody.ReadFrom(response.Body)
+
+	log.Printf("[INFO] CLIENT | LB DELETE | Response code: %d", response.StatusCode)
+	log.Printf("[INFO] CLIENT | LB DELETE | Response body: %s", respBody.String())
+
 	if response.StatusCode != http.StatusOK {
-		respBody := new(bytes.Buffer)
-		_, err := respBody.ReadFrom(response.Body)
-		if err != nil {
-			return fmt.Errorf("got a non 200 status code: %v", response.StatusCode)
-		}
 		return fmt.Errorf("got a non 200 status code: %v - %s", response.StatusCode, respBody.String())
 	}
 
+	log.Printf("[INFO] CLIENT | LB DELETE | Successfully deleted Load Balancer ID: %s", lbId)
 	return nil
 }
 

--- a/client/lb_client.go
+++ b/client/lb_client.go
@@ -114,71 +114,26 @@ func (c *Client) GetLoadBalancerInfo(lbId string, location string, project_id st
 	return jsonRes, nil
 }
 
-// func (c *Client) DeleteLoadBalancer(lbId string, location string, project_id string) error {
-// 	urlLbInfo := c.Api_endpoint + "appliances/" + lbId + "/"
-// 	req, err := http.NewRequest("DELETE", urlLbInfo, nil)
-// 	if err != nil {
-// 		return err
-// 	}
-
-// 	log.Printf("[INFO] CLIENT | LOAD BALANCER DELETE")
-
-// 	req, err = c.AddParamsAndHeader(req, location, project_id)
-// 	if err != nil {
-// 		return err
-// 	}
-
-// 	response, err := c.HttpClient.Do(req)
-// 	if err != nil {
-// 		return err
-// 	}
-// 	if response.StatusCode != http.StatusOK {
-// 		respBody := new(bytes.Buffer)
-// 		_, err := respBody.ReadFrom(response.Body)
-// 		if err != nil {
-// 			return fmt.Errorf("got a non 200 status code: %v", response.StatusCode)
-// 		}
-// 		return fmt.Errorf("got a non 200 status code: %v - %s", response.StatusCode, respBody.String())
-// 	}
-
-// 	return nil
-// }
-
 func (c *Client) DeleteLoadBalancer(lbId string, location string, project_id string) error {
 	urlLbInfo := c.Api_endpoint + "appliances/" + lbId + "/"
-	log.Printf("[INFO] CLIENT | LB DELETE | Request URL: %s", urlLbInfo)
-
 	req, err := http.NewRequest("DELETE", urlLbInfo, nil)
 	if err != nil {
-		log.Printf("[ERROR] CLIENT | LB DELETE | Failed to create request: %v", err)
 		return err
 	}
 
 	req, err = c.AddParamsAndHeader(req, location, project_id)
 	if err != nil {
-		log.Printf("[ERROR] CLIENT | LB DELETE | Failed to add headers/params: %v", err)
 		return err
 	}
 
-	log.Printf("[INFO] CLIENT | LB DELETE | Sending DELETE request for LB ID: %s, Location: %s, Project: %s", lbId, location, project_id)
 	response, err := c.HttpClient.Do(req)
 	if err != nil {
-		log.Printf("[ERROR] CLIENT | LB DELETE | Request failed: %v", err)
 		return err
 	}
-	defer response.Body.Close()
-
-	respBody := new(bytes.Buffer)
-	_, _ = respBody.ReadFrom(response.Body)
-
-	log.Printf("[INFO] CLIENT | LB DELETE | Response code: %d", response.StatusCode)
-	log.Printf("[INFO] CLIENT | LB DELETE | Response body: %s", respBody.String())
-
 	if response.StatusCode != http.StatusOK {
 		return fmt.Errorf("got a non 200 status code: %v - %s", response.StatusCode, respBody.String())
 	}
 
-	log.Printf("[INFO] CLIENT | LB DELETE | Successfully deleted Load Balancer ID: %s", lbId)
 	return nil
 }
 

--- a/docs/resources/loadbalancer.md
+++ b/docs/resources/loadbalancer.md
@@ -49,7 +49,7 @@ This resource allows you to manage loadbalancer on your e2e clusters. When appli
   vpc_list = [e2e_vpc.VPC-TS-01.id]
 
   is_ipv6_attached = false
-  project_id="your_project_id"
+  project_id="12345"    # Replace with your actual project ID
 }
 
 

--- a/docs/resources/loadbalancer.md
+++ b/docs/resources/loadbalancer.md
@@ -25,15 +25,15 @@ This resource allows you to manage loadbalancer on your e2e clusters. When appli
 
   backends {
     balance         = "source"
-    name= "backend-server-ts"
+    name            = "backend-server-ts"
 
     servers {
-      id = 163745 // just for an example
-      port = 8000 // just for an example
+      id = 163745  # Replace with your node or server ID
+      port = 8000  # Replace with desired port
     }
      servers {
-      id = 149020 // just for an example
-      port = 8080 // just for an example
+      id = 149020  # Replace with your node or server ID
+      port = 8080  # Replace with desired port
     }
     http_check = false
   }

--- a/docs/resources/loadbalancer.md
+++ b/docs/resources/loadbalancer.md
@@ -28,12 +28,12 @@ This resource allows you to manage loadbalancer on your e2e clusters. When appli
     name= "backend-server-ts"
 
     servers {
-      id = 163745
-      port = 8000
+      id = 163745 // just for an example
+      port = 8000 // just for an example
     }
      servers {
-      id = 149020
-      port = 8080
+      id = 149020 // just for an example
+      port = 8080 // just for an example
     }
     http_check = false
   }
@@ -49,13 +49,14 @@ This resource allows you to manage loadbalancer on your e2e clusters. When appli
   vpc_list = [e2e_vpc.VPC-TS-01.id]
 
   is_ipv6_attached = false
-  project_id=22878
+  project_id="your_project_id"
 }
 
 
 resource "e2e_vpc" "VPC-TS-01" {
-  region="Delhi"
+  location="Delhi"
   vpc_name="VPC-TS-01"
+  project_id="your_project_id"
 }
 ```
 

--- a/docs/resources/sfs.md
+++ b/docs/resources/sfs.md
@@ -16,7 +16,7 @@ Provides an e2e node resource. provides an on-demand, scalable, and high-perform
     plan   = "5GB"
     vpc_id = "143"
     disk_size = 5
-    project_id = "325"
+    project_id = "your_project_id"
     disk_iops = 75
     region = "Delhi"
  }

--- a/docs/resources/sfs.md
+++ b/docs/resources/sfs.md
@@ -16,7 +16,7 @@ Provides an e2e node resource. provides an on-demand, scalable, and high-perform
     plan   = "5GB"
     vpc_id = "143"
     disk_size = 5
-    project_id = "your_project_id"
+    project_id = "12345"  # Replace with your actual project ID
     disk_iops = 75
     region = "Delhi"
  }

--- a/docs/resources/vpc.md
+++ b/docs/resources/vpc.md
@@ -17,7 +17,7 @@ This resource allows you to manage vpc on your e2e clusters. When applied, a new
  resource "e2e_vpc" "vpc1" {
     vpc_name            = "vpc_name"
     location            = "Delhi"
-    project_id          = "123456"
+    project_id          = "your_project_id"
  }
 ```
 ## Schema

--- a/docs/resources/vpc.md
+++ b/docs/resources/vpc.md
@@ -17,7 +17,7 @@ This resource allows you to manage vpc on your e2e clusters. When applied, a new
  resource "e2e_vpc" "vpc1" {
     vpc_name            = "vpc_name"
     location            = "Delhi"
-    project_id          = "your_project_id"
+    project_id          = "12345"  # Replace with your actual project ID
  }
 ```
 ## Schema

--- a/e2e/loadbalancer/resource_loadbalancer.go
+++ b/e2e/loadbalancer/resource_loadbalancer.go
@@ -422,9 +422,10 @@ func CreateLoadBalancerObject(apiClient *client.Client, d *schema.ResourceData) 
 		EnableBitninja:   d.Get("enable_bitninja").(bool),
 		IsIpv6Attached:   d.Get("is_ipv6_attached").(bool),
 		DefaultBackend:   d.Get("default_backend").(string),
+		Location: 		  d.Get("location").(string),
 	}
 	enableEosLogger, ok := d.GetOk("enable_eos_logger")
-	if ok {
+		if ok {
 		eosDetail, err := ExpandEnableEosLogger(enableEosLogger.(*schema.Set).List())
 		if err != nil {
 			return nil, diag.FromErr(err)

--- a/e2e/loadbalancer/resource_loadbalancer.go
+++ b/e2e/loadbalancer/resource_loadbalancer.go
@@ -425,7 +425,7 @@ func CreateLoadBalancerObject(apiClient *client.Client, d *schema.ResourceData) 
 		Location: 		  d.Get("location").(string),
 	}
 	enableEosLogger, ok := d.GetOk("enable_eos_logger")
-		if ok {
+	if ok {
 		eosDetail, err := ExpandEnableEosLogger(enableEosLogger.(*schema.Set).List())
 		if err != nil {
 			return nil, diag.FromErr(err)

--- a/models/appliances.go
+++ b/models/appliances.go
@@ -20,6 +20,7 @@ type LoadBalancerCreate struct {
 	TcpBackend       []TcpBackendDetail     `json:"tcp_backend"`
 	IsIpv6Attached   bool                   `json:"is_ipv6_attached"`
 	DefaultBackend   string                 `json:"default_backend"`
+	Location         string                 `json:"location"`
 }
 
 type Backend struct {


### PR DESCRIPTION
- Added the location field to the LoadBalancer schema to resolve the "location missing or incorrect" error.
- Updated documentation for LoadBalancer, VPC, and SFS:
        - Clearly marked fields that are user-specific (e.g., project ID, VPC ID).
        - Corrected field types that were incorrectly marked as integer but are actually string.
        - Removed hardcoded sample IDs and replaced them with guidance text instructing users to enter their own IDs.