### PR TITLE
fix: use resource-specific import function for e2e_reserved_ip

### DIFF
--- a/docs/resources/reserved_ip.md
+++ b/docs/resources/reserved_ip.md
@@ -41,3 +41,11 @@ This resource allows you to manage reserved ip on your e2e clusters. When applie
 - `status` (String) status of the reserve_ip (example - Attached, Available)
 - `vm_id` (String) ID of virtual machine from whom it is attached
 - `vm_name` (String) vm name from whom it is attached
+
+## Import
+
+Reserved IPs can be imported using `project_id/location/ip_address`:
+
+```shell
+terraform import e2e_reserved_ip.example 12345/Delhi/103.209.145.67
+```

--- a/e2e/reserve_ip/resource_reserve_ip.go
+++ b/e2e/reserve_ip/resource_reserve_ip.go
@@ -187,7 +187,9 @@ func resourceReadReserveIP(ctx context.Context, d *schema.ResourceData, m interf
 	log.Printf("[INFO] FILTER DATA | %+v %T", data, data)
 
 	if data.IPAddress == "" {
-		return diag.Errorf("Cannot find reserve_ip with address : %s", reserveId)
+		log.Printf("[WARN] ReserveIP READ | reserve_ip with address %s not found, removing from state", reserveId)
+		d.SetId("")
+		return diags
 	} else {
 		d.SetId(strconv.Itoa(int(math.Round(data.ReserveID))))
 		log.Printf("[INFO] ReserveIP READ | BEFORE SETTING DATA %+v, %v, %T =======================", data, data.Status, data.Status)


### PR DESCRIPTION
The importer for `e2e_reserved_ip` reused `node.CustomImportStateFunc`, which sets `node_id` — a field that doesn't exist on the reserved_ip schema. This meant `ip_address` was never set, so the Read function couldn't find the resource and import always failed.

This PR adds a dedicated `reserveIPImportStateFunc` that correctly parses `project_id/location/ip_address` from the import ID and sets the right fields. It also adds `d.SetId()` in the Read function so the Terraform resource ID transitions from the temporary IP address to the actual `reserve_id`.