### PR TITLE
Node Creation Fixed for E1 Series Node and Fix the existing issue

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -315,6 +315,46 @@ func (c *Client) UpgradeNodePlan(nodeId string, plan string, image string, proje
 	return response, err
 }
 
+func (c *Client) ResizeNodeDisk(nodeId string, disk int, project_id string, location string) (interface{}, error) {
+	diskAction := models.NodeDiskResizeAction{
+		Disk_size: disk,
+	}
+	body, err := json.Marshal(diskAction)
+	if err != nil {
+		return nil, err
+	}
+	url := c.Api_endpoint + "nodes/" + nodeId + "/root-storage-upgrade/"
+	req, err := http.NewRequest("PUT", url, bytes.NewBuffer(body))
+	if err != nil {
+		return nil, err
+	}
+	params := req.URL.Query()
+	params.Add("apikey", c.Api_key)
+	params.Add("project_id", project_id)
+	params.Add("location", location)
+	req.Header.Add("Authorization", "Bearer "+c.Auth_token)
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("User-Agent", "terraform-e2e")
+	req.URL.RawQuery = params.Encode()
+	response, err := c.HttpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if response.StatusCode != http.StatusOK {
+		respBody := new(bytes.Buffer)
+		_, err := respBody.ReadFrom(response.Body)
+		if err != nil {
+			return nil, fmt.Errorf("got a non 200 status code: %v", response.StatusCode)
+		}
+		return nil, fmt.Errorf("got a non 200 status code: %v - %s", response.StatusCode, respBody.String())
+	}
+	defer response.Body.Close()
+	resBody, _ := ioutil.ReadAll(response.Body)
+	var jsonRes map[string]interface{}
+	json.Unmarshal(resBody, &jsonRes)
+	return jsonRes, nil
+}
+
 func (c *Client) DeleteNode(nodeId string, project_id string, location string) error {
 
 	urlNode := c.Api_endpoint + "nodes/" + nodeId + "/"
@@ -556,6 +596,48 @@ func (c *Client) DeleteVpc(vpcId string, project_id string, location string) (ma
 	}
 	return jsonRes, nil
 }
+func (c *Client) PublicIPAction(publicIP string, action string, vmID int, project_id string, location string) (map[string]interface{}, error) {
+	payload := models.PublicIPAction{
+		PublicIP: publicIP,
+		Type:     action,
+		VmID:     vmID,
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	url := c.Api_endpoint + "reserve_ips/public_reserveip_actions/"
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(body))
+	if err != nil {
+		return nil, err
+	}
+	params := req.URL.Query()
+	params.Add("apikey", c.Api_key)
+	params.Add("project_id", project_id)
+	params.Add("location", location)
+	req.Header.Add("Authorization", "Bearer "+c.Auth_token)
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("User-Agent", "terraform-e2e")
+	req.URL.RawQuery = params.Encode()
+	response, err := c.HttpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if response.StatusCode != http.StatusOK {
+		respBody := new(bytes.Buffer)
+		_, err := respBody.ReadFrom(response.Body)
+		if err != nil {
+			return nil, fmt.Errorf("got a non 200 status code: %v", response.StatusCode)
+		}
+		return nil, fmt.Errorf("got a non 200 status code: %v - %s", response.StatusCode, respBody.String())
+	}
+	defer response.Body.Close()
+	resBody, _ := ioutil.ReadAll(response.Body)
+	var jsonRes map[string]interface{}
+	json.Unmarshal(resBody, &jsonRes)
+	return jsonRes, nil
+}
+
 func (c *Client) NewReservedIp(project_id string, location string) (map[string]interface{}, error) {
 
 	UrlReservedIp := c.Api_endpoint + "reserve_ips/"

--- a/client/client.go
+++ b/client/client.go
@@ -340,6 +340,7 @@ func (c *Client) ResizeNodeDisk(nodeId string, disk int, project_id string, loca
 	if err != nil {
 		return nil, err
 	}
+	defer response.Body.Close()
 	if response.StatusCode != http.StatusOK {
 		respBody := new(bytes.Buffer)
 		_, err := respBody.ReadFrom(response.Body)
@@ -348,7 +349,6 @@ func (c *Client) ResizeNodeDisk(nodeId string, disk int, project_id string, loca
 		}
 		return nil, fmt.Errorf("got a non 200 status code: %v - %s", response.StatusCode, respBody.String())
 	}
-	defer response.Body.Close()
 	resBody, _ := ioutil.ReadAll(response.Body)
 	var jsonRes map[string]interface{}
 	json.Unmarshal(resBody, &jsonRes)
@@ -623,6 +623,7 @@ func (c *Client) PublicIPAction(publicIP string, action string, vmID int, projec
 	if err != nil {
 		return nil, err
 	}
+	defer response.Body.Close()
 	if response.StatusCode != http.StatusOK {
 		respBody := new(bytes.Buffer)
 		_, err := respBody.ReadFrom(response.Body)
@@ -631,7 +632,6 @@ func (c *Client) PublicIPAction(publicIP string, action string, vmID int, projec
 		}
 		return nil, fmt.Errorf("got a non 200 status code: %v - %s", response.StatusCode, respBody.String())
 	}
-	defer response.Body.Close()
 	resBody, _ := ioutil.ReadAll(response.Body)
 	var jsonRes map[string]interface{}
 	json.Unmarshal(resBody, &jsonRes)

--- a/docs/data-sources/node.md
+++ b/docs/data-sources/node.md
@@ -18,6 +18,8 @@ description: |-
 ### Argument Reference
 
 - `node_id` (String) The id of the node is required to read that node.
+- `location` (String) Location of the node (e.g. `"Delhi"`, `"Chennai"`).
+- `project_id` (String) The ID of the project associated with the node.
 
 ### Attribute Reference (Read Only)
 
@@ -31,6 +33,7 @@ description: |-
 - `is_active` (Boolean)
 - `is_bitninja_license_active` (Boolean) Can check if the bitninja license is active or not
 - `is_monitored` (Boolean)
+- `is_encryption_enabled` (Boolean) Whether encryption is enabled on the node.
 - `memory` (String) memory of the node
 - `price` (String) price details of the node
 - `private_ip_address` (String) Private ip address alloted to node if any

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ terraform {
  required_providers {
    e2e = {
      source = "e2eterraformprovider/e2e"
-     version = "2.2.10"
+     version = "2.2.11"
    }
  }
 }

--- a/docs/resources/node.md
+++ b/docs/resources/node.md
@@ -37,12 +37,14 @@ This resource allows you to manage nodes on your e2e clusters. When applied, a n
 - `label` : (Optional)(String) The name of the group . Default value is "default"
 - `backup` : (Optional)(Boolean) Tells you the state of your backups
 - `default_public_ip` : (Optional) (Boolean) Tells us the state of default public ip
-- `default_public_ip` : (Optional) (Boolean) Tells us the state of default public ip
 - `disable_password` :(Optional) (Boolean) can disable password as per requirement
 - `enable_bitninja` : (Optional) (Boolean) enable bitnija as per requirement
 - `is_ipv6_availed` : (Optional)(Boolean)
 - `is_saved_image` : (Optional) (Boolean)  Creating node from a saved image when set true.
-- `reserve_ip` : (Optional) (String) Reserve ip as per  requirement
+- `reserve_ip` : (Optional) (String) Attach a reserved IP to the node. Must be a valid IP address. Can be attached or detached after node creation. To detach, set to empty string `""` or remove the field.
+- `disk` : (Optional) (String) Root disk size in GB (e.g. `"100"`). **Only applicable for E1 Series nodes.** Must be at least 75 GB and less than 2400 GB. Values up to 150 GB must be multiples of 25; values above 150 GB must be multiples of 50. Cannot be decreased after creation.
+- `is_encryption_enabled` : (Optional) (Boolean) Enable encryption for the node. Default is `false`. **Cannot be changed after node creation.**
+- `encryption_passphrase` : (Optional) (String, Sensitive) Passphrase for node encryption. Used only when `is_encryption_enabled` is `true`. **Cannot be changed after node creation.**
 - `saved_image_template_id` :  (Optional) (Number) template id  is required when you save the node from saved images.Give the template id of the saved image. Required when is_saved_image field is true
 - `ssh_keys` : (Optional) (List of String) Specify the label of ssh keys as required. Checkout ssh_keys datasource for listing ssh keys
 - `vpc_id` : (Optional) (String) Vpc id as per requirement. Checkout vpcs_datasource for listing vpcs. To find the vpc id, please refer to our [`API Documentation`](https://docs.e2enetworks.com/api/myaccount/#/paths/vpc-list/get)

--- a/e2e/node/datasource_node.go
+++ b/e2e/node/datasource_node.go
@@ -97,6 +97,11 @@ func DataSourceNode() *schema.Resource {
 				ForceNew:    true,
 				Description: "The ID of the project associated with the node",
 			},
+			"is_encryption_enabled":{
+				Type: 		 schema.TypeBool,
+				Computed: 	 true,
+				Description: "Encryption is enabled or not",
+			},
 		},
 
 		ReadContext: dataSourceReadNode,
@@ -130,6 +135,9 @@ func dataSourceReadNode(ctx context.Context, d *schema.ResourceData, m interface
 	d.Set("public_ip_address", data["public_ip_address"].(string))
 	d.Set("private_ip_address", data["private_ip_address"].(string))
 	d.Set("is_bitninja_license_active", data["is_bitninja_license_active"].(bool))
+	if encEnabled, ok := data["isEncryptionEnabled"].(bool); ok {
+		d.Set("is_encryption_enabled", encEnabled)
+	}
 	log.Printf("[INFO] NODE DATA SOURCE | d : %+v", *d)
 
 	return diags

--- a/e2e/node/resource_node.go
+++ b/e2e/node/resource_node.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"math"
+	"net"
 	"regexp"
 	"strconv"
 	"strings"
@@ -98,9 +99,11 @@ func ResourceNode() *schema.Resource {
 				Description: "The script to be run on the node first created",
 			},
 			"reserve_ip": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "Attach reserve ip as per requirement",
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "",
+				Description:  "Attach reserve ip as per requirement",
+				ValidateFunc: validateIPAddress,
 			},
 			"vpc_id": {
 				Type:        schema.TypeString,
@@ -154,8 +157,9 @@ func ResourceNode() *schema.Resource {
 			},
 			"disk": {
 				Type:        schema.TypeString,
-				Computed:    true,
 				Description: "Disc info of the node",
+				Optional:    true,
+				Computed:    true,
 			},
 			"price": {
 				Type:        schema.TypeString,
@@ -231,6 +235,19 @@ func ResourceNode() *schema.Resource {
 					ValidateFunc: validation.All(ValidateBlank, ValidateInteger),
 				},
 			},
+			"is_encryption_enabled":{
+				Type:			schema.TypeBool,
+				Optional:   	true,
+				Description: 	"Encryption for the node",
+				Default: 		false,
+			},
+			"encryption_passphrase":{
+				Type:			schema.TypeString,
+				Sensitive:		true,
+				Optional: 		true,
+				Description: 	"Encryption passphrase provided by the user",
+				Default:		"",
+			},
 		},
 
 		CreateContext: resourceCreateNode,
@@ -242,6 +259,36 @@ func ResourceNode() *schema.Resource {
 			State: CustomImportStateFunc,
 		},
 	}
+}
+
+func validateIPAddress(v interface{}, k string) (ws []string, es []error) {
+	value := v.(string)
+	if value == "" {
+		return
+	}
+	if net.ParseIP(value) == nil {
+		es = append(es, fmt.Errorf("%q is not a valid IP address", value))
+	}
+	return
+}
+
+func validateDiskSize(diskSize int) error {
+	if diskSize < 75 {
+		return fmt.Errorf("disk size must be at least 75 GB")
+	}
+	if diskSize >= 2400 {
+		return fmt.Errorf("disk size must be less than 2400 GB")
+	}
+	if diskSize > 150 {
+		if diskSize%50 != 0 {
+			return fmt.Errorf("disk size greater than 150 GB must be a multiple of 50")
+		}
+	} else {
+		if diskSize%25 != 0 {
+			return fmt.Errorf("disk size must be a multiple of 25")
+		}
+	}
+	return nil
 }
 
 func ValidateName(v interface{}, k string) (ws []string, es []error) {
@@ -321,6 +368,21 @@ func resourceCreateNode(ctx context.Context, d *schema.ResourceData, m interface
 		}
 	}
 
+	disk_size := d.Get("disk").(string)
+	_, diskProvided := d.GetOk("disk")
+	plan := d.Get("plan").(string)
+
+	if plan[0:2] != "E1" && diskProvided {
+		return diag.Errorf("Disk size can be provided only for E1 Series of nodes")
+	}
+
+	diskInt, _ := strconv.Atoi(disk_size)
+	if diskProvided {
+		if err := validateDiskSize(diskInt); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
 	node := models.NodeCreate{
 		Name:                    d.Get("name").(string),
 		Label:                   d.Get("label").(string),
@@ -339,6 +401,9 @@ func resourceCreateNode(ctx context.Context, d *schema.ResourceData, m interface
 		SSH_keys:                d.Get("ssh_keys").([]interface{}),
 		Start_scripts:           GetStartScripts(d.Get("start_script").(string)),
 		Image_id:                image_id,
+		Disk:                    diskInt,
+		IsEncryptionEnabled:	 d.Get("is_encryption_enabled").(bool),
+		EncryptionPassphrase: 	 d.Get("encryption_passphrase").(string),
 	}
 
 	if node.Vpc_id != "" {
@@ -375,9 +440,12 @@ func resourceCreateNode(ctx context.Context, d *schema.ResourceData, m interface
 	d.Set("created_at", data["created_at"].(string))
 	d.Set("memory", data["memory"].(string))
 	d.Set("status", data["status"].(string))
-	d.Set("disk", data["disk"].(string))
+	d.Set("disk", strings.Fields(data["disk"].(string))[0])
 	d.Set("price", data["price"].(string))
 	d.Set("vm_id", int(data["vm_id"].(float64)))
+	if encEnabled, ok := data["isEncryptionEnabled"].(bool); ok {
+		d.Set("is_encryption_enabled", encEnabled)
+	}
 	return diags
 }
 
@@ -386,6 +454,7 @@ func resourceReadNode(ctx context.Context, d *schema.ResourceData, m interface{}
 	apiClient := m.(*client.Client)
 	var diags diag.Diagnostics
 	copy_ssh_keys := d.Get("ssh_keys")
+	copy_plan := d.Get("plan")
 	log.Printf("[info] inside node Resource read")
 	nodeId := d.Id()
 	project_id := d.Get("project_id").(string)
@@ -404,11 +473,11 @@ func resourceReadNode(ctx context.Context, d *schema.ResourceData, m interface{}
 	log.Printf("[info] node Resource read | data = %+v", data)
 	d.Set("name", data["name"].(string))
 	d.Set("label", data["label"].(string))
-	d.Set("plan", data["plan"].(string))
+	d.Set("plan", copy_plan)
 	d.Set("created_at", data["created_at"].(string))
 	d.Set("memory", data["memory"].(string))
 	d.Set("status", data["status"].(string))
-	d.Set("disk", data["disk"].(string))
+	d.Set("disk", strings.Fields(data["disk"].(string))[0])
 	d.Set("price", data["price"].(string))
 	d.Set("lock_node", data["is_locked"].(bool))
 	d.Set("public_ip_address", data["public_ip_address"].(string))
@@ -416,6 +485,9 @@ func resourceReadNode(ctx context.Context, d *schema.ResourceData, m interface{}
 	d.Set("is_bitninja_license_active", data["is_bitninja_license_active"].(bool))
 	d.Set("ssh_keys", copy_ssh_keys)
 	d.Set("vm_id", int(data["vm_id"].(float64)))
+	if encEnabled, ok := data["isEncryptionEnabled"].(bool); ok {
+		d.Set("is_encryption_enabled", encEnabled)
+	}
 
 	log.Printf("[info] node Resource read | after setting data")
 	if d.Get("status").(string) == "Running" || d.Get("status").(string) == "Creating" {
@@ -454,9 +526,51 @@ func resourceUpdateNode(ctx context.Context, d *schema.ResourceData, m interface
 	}
 
 	if d.HasChange("start_script") {
-		start_script, _ := d.GetChange("start_script")
-		d.Set("location", start_script)
 		return diag.Errorf("start_script cannot be updated once you create the node.")
+	}
+
+	if d.HasChange("disk") {
+		oldDisk, newDisk := d.GetChange("disk")
+		if d.Get("plan").(string)[0:2] != "E1" {
+			d.Set("disk", oldDisk)
+			return diag.Errorf("Disk size can be updated only for E1 Series of nodes")
+		}
+		newDiskInt, _ := strconv.Atoi(newDisk.(string))
+		if err := validateDiskSize(newDiskInt); err != nil {
+			d.Set("disk", oldDisk)
+			return diag.FromErr(err)
+		}
+		_, err := apiClient.ResizeNodeDisk(nodeId, newDiskInt, project_id, location)
+		if err != nil {
+			d.Set("disk", oldDisk)
+			return diag.FromErr(err)
+		}
+	}
+
+	if d.HasChange("is_encryption_enabled") || d.HasChange("encryption_passphrase") {
+		return diag.Errorf("is_encryption_enabled and encryption_passphrase cannot be updated after node creation.")
+	}
+
+	if d.HasChange("reserve_ip") {
+		oldIP, newIP := d.GetChange("reserve_ip")
+		vmID := d.Get("vm_id").(int)
+		if oldIP.(string) != "" && newIP.(string) != "" {
+			d.Set("reserve_ip", oldIP)
+			return diag.Errorf("cannot attach a new reserve_ip while one is already attached. Remove the existing IP first.")
+		}
+		if newIP.(string) != "" {
+			_, err := apiClient.PublicIPAction(newIP.(string), "attach", vmID, project_id, location)
+			if err != nil {
+				d.Set("reserve_ip", oldIP)
+				return diag.FromErr(err)
+			}
+		} else {
+			_, err := apiClient.PublicIPAction(oldIP.(string), "detach", vmID, project_id, location)
+			if err != nil {
+				d.Set("reserve_ip", oldIP)
+				return diag.FromErr(err)
+			}
+		}
 	}
 
 	if d.HasChange("name") {
@@ -994,6 +1108,9 @@ func rollbackChanges(d *schema.ResourceData) {
 	prevPowerStatus, _ := d.GetChange("power_status")
 	prevRebootNode, _ := d.GetChange("reboot_node")
 	prevReinstallNode, _ := d.GetChange("reinstall_node")
+	prevDisk, _ := d.GetChange("disk")
+	prevIsEncryptionEnabled, _ := d.GetChange("is_encryption_enabled")
+	prevEncryptionPassphrase, _ := d.GetChange("encryption_passphrase")
 
 	d.Set("image", prevImage)
 	d.Set("name", prevName)
@@ -1019,4 +1136,7 @@ func rollbackChanges(d *schema.ResourceData) {
 	d.Set("power_status", prevPowerStatus)
 	d.Set("reboot_node", prevRebootNode)
 	d.Set("reinstall_node", prevReinstallNode)
+	d.Set("disk", prevDisk)
+	d.Set("is_encryption_enabled", prevIsEncryptionEnabled)
+	d.Set("encryption_passphrase", prevEncryptionPassphrase)
 }

--- a/e2e/node/resource_node.go
+++ b/e2e/node/resource_node.go
@@ -372,7 +372,7 @@ func resourceCreateNode(ctx context.Context, d *schema.ResourceData, m interface
 	_, diskProvided := d.GetOk("disk")
 	plan := d.Get("plan").(string)
 
-	if plan[0:2] != "E1" && diskProvided {
+	if !strings.HasPrefix(plan, "E1") && diskProvided {
 		return diag.Errorf("Disk size can be provided only for E1 Series of nodes")
 	}
 
@@ -440,7 +440,11 @@ func resourceCreateNode(ctx context.Context, d *schema.ResourceData, m interface
 	d.Set("created_at", data["created_at"].(string))
 	d.Set("memory", data["memory"].(string))
 	d.Set("status", data["status"].(string))
-	d.Set("disk", strings.Fields(data["disk"].(string))[0])
+	if diskVal, ok := data["disk"].(string); ok {
+		if fields := strings.Fields(diskVal); len(fields) > 0 {
+			d.Set("disk", fields[0])
+		}
+	}
 	d.Set("price", data["price"].(string))
 	d.Set("vm_id", int(data["vm_id"].(float64)))
 	if encEnabled, ok := data["isEncryptionEnabled"].(bool); ok {
@@ -477,7 +481,11 @@ func resourceReadNode(ctx context.Context, d *schema.ResourceData, m interface{}
 	d.Set("created_at", data["created_at"].(string))
 	d.Set("memory", data["memory"].(string))
 	d.Set("status", data["status"].(string))
-	d.Set("disk", strings.Fields(data["disk"].(string))[0])
+	if diskVal, ok := data["disk"].(string); ok {
+		if fields := strings.Fields(diskVal); len(fields) > 0 {
+			d.Set("disk", fields[0])
+		}
+	}
 	d.Set("price", data["price"].(string))
 	d.Set("lock_node", data["is_locked"].(bool))
 	d.Set("public_ip_address", data["public_ip_address"].(string))
@@ -531,7 +539,7 @@ func resourceUpdateNode(ctx context.Context, d *schema.ResourceData, m interface
 
 	if d.HasChange("disk") {
 		oldDisk, newDisk := d.GetChange("disk")
-		if d.Get("plan").(string)[0:2] != "E1" {
+		if !strings.HasPrefix(d.Get("plan").(string), "E1") {
 			d.Set("disk", oldDisk)
 			return diag.Errorf("Disk size can be updated only for E1 Series of nodes")
 		}

--- a/models/node.go
+++ b/models/node.go
@@ -20,7 +20,11 @@ type NodeCreate struct {
 	SSH_keys                []interface{} `json:"ssh_keys"`
 	Start_scripts           []interface{} `json:"start_scripts"`
 	Image_id                int           `json:"image_id"`
+	Disk                    int           `json:"disk,omitempty"`
+	IsEncryptionEnabled		bool		  `json:"isEncryptionEnabled"`
+	EncryptionPassphrase	string		  `json:"encryption_passphrase,omitempty"`
 }
+
 type NodeAction struct {
 	Type string `json:"type"`
 	Name string `json:"name"`
@@ -34,6 +38,16 @@ type NodeActionSSH struct {
 type NodePlanUpgradeAction struct {
 	Plan  string `json:"plan"`
 	Image string `json:"image"`
+}
+
+type NodeDiskResizeAction struct {
+	Disk_size int `json:"disk_size"`
+}
+
+type PublicIPAction struct {
+	PublicIP string `json:"public_ip"`
+	Type     string `json:"type"`
+	VmID     int    `json:"vm_id"`
 }
 
 type ResponseNodes struct {


### PR DESCRIPTION
Node creation fixed for the E1 Series node.
Users can attach and detach Reserved IPs from the node.
Users can enable encryption through Terraform.
Added checks for disk size increases to allow only valid disk sizes.